### PR TITLE
add placement_policy, placement_group_id, placement_affinity_rules

### DIFF
--- a/examples/full/main.tf
+++ b/examples/full/main.tf
@@ -1,5 +1,5 @@
 module "yandex_compute_instance" {
-  source = "../"
+  source = "../../"
 
   folder_id = "xxx"
 

--- a/examples/full/main.tf
+++ b/examples/full/main.tf
@@ -1,7 +1,27 @@
+data "yandex_client_config" "client" {}
+
+module "network" {
+  source = "git::https://github.com/terraform-yacloud-modules/terraform-yandex-vpc.git?ref=v1.0.0"
+
+  folder_id = data.yandex_client_config.client.folder_id
+
+  blank_name = "vpc-nat-gateway"
+  labels = {
+    repo = "terraform-yacloud-modules/terraform-yandex-vpc"
+  }
+
+  azs = ["ru-central1-a"]
+
+  private_subnets = [["10.10.10.0/24"]]
+
+  create_vpc         = true
+  create_nat_gateway = true
+}
+
 module "yandex_compute_instance" {
   source = "../../"
 
-  folder_id = "xxx"
+  folder_id = data.yandex_client_config.client.folder_id
 
   name         = "my-instance"
   description  = "Test instance"
@@ -12,7 +32,7 @@ module "yandex_compute_instance" {
   }
 
   zone                      = "ru-central1-a"
-  subnet_id                 = "xxx"
+  subnet_id                 = module.network.private_subnets_ids[0]
   enable_nat                = true
   create_pip                = true
   network_acceleration_type = "standard"

--- a/examples/full/versions.tf
+++ b/examples/full/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_providers {
+    yandex = {
+      source  = "yandex-cloud/yandex"
+      version = ">= 0.72.0"
+    }
+  }
+  required_version = ">= 1.3"
+}

--- a/main.tf
+++ b/main.tf
@@ -41,20 +41,19 @@ resource "yandex_compute_instance" "this" {
     preemptible = var.preemptible
   }
 
-  # TODO
-  #  placement_policy {
-  #    placement_group_id = var.placement_group_id
-  #
-  #    dynamic "host_affinity_rules" {
-  #      for_each = var.placement_affinity_rules
-  #
-  #      content {
-  #        key   = host_affinity_rules.value["key"]
-  #        op    = host_affinity_rules.value["op"]
-  #        value = host_affinity_rules.value["value"]
-  #      }
-  #    }
-  #  }
+  placement_policy {
+    placement_group_id = var.placement_group_id
+
+    dynamic "host_affinity_rules" {
+      for_each = var.placement_affinity_rules
+
+      content {
+        key    = host_affinity_rules.value["key"]
+        op     = host_affinity_rules.value["op"]
+        values = host_affinity_rules.value["value"]
+      }
+    }
+  }
 
   resources {
     cores         = var.cores

--- a/variables.tf
+++ b/variables.tf
@@ -146,7 +146,7 @@ variable "preemptible" {
 variable "placement_group_id" {
   description = "Placement group ID"
   type        = string
-  default     = null
+  default     = ""
 }
 
 variable "placement_affinity_rules" {

--- a/variables.tf
+++ b/variables.tf
@@ -143,21 +143,21 @@ variable "preemptible" {
   default     = false
 }
 
-# variable "placement_group_id" {
-#   description = "Placement group ID"
-#   type        = string
-#   default     = null
-# }
-#
-# variable "placement_affinity_rules" {
-#   description = "List of host affinity rules"
-#   type = list(object({
-#     key   = string
-#     op    = string
-#     value = string
-#   }))
-#   default = []
-# }
+variable "placement_group_id" {
+  description = "Placement group ID"
+  type        = string
+  default     = null
+}
+
+variable "placement_affinity_rules" {
+  description = "List of host affinity rules"
+  type = list(object({
+    key   = string
+    op    = string
+    value = list(string)
+  }))
+  default = []
+}
 
 #
 # vm image


### PR DESCRIPTION
Example рабочий. Что интересно, если указать ` value = host_affinity_rules.value["value"]`


```
│ Error: Unsupported argument
│ 
│   on ../../main.tf line 53, in resource "yandex_compute_instance" "this":
│   53:         value = host_affinity_rules.value["value"]
│ 
│ An argument named "value" is not expected here. Did you mean "values"?
```

Возможно здесь ошибка https://registry.terraform.io/providers/yandex-cloud/yandex/latest/docs/resources/compute_instance#host_affinity_rules