### PR TITLE
Pin Checkov action to major version v12 to reduce Dependabot noise

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -60,7 +60,7 @@ jobs:
           soft_fail: true
       -
         name: Test code with Checkov
-        uses: bridgecrewio/checkov-action@v12.2940.0
+        uses: bridgecrewio/checkov-action@v12
         with:
           directory: /
           framework: terraform


### PR DESCRIPTION
**Git Commit Name:**
"Pin Checkov action to major version v12 to reduce Dependabot noise"

**Description:**
This PR pins the Checkov action to the major version `v12` instead of a specific patch version (`v12.2943.0`). This change is made to reduce the frequency of Dependabot pull requests for minor or patch updates, as we are comfortable using the latest stable version within the `v12` major release.

**Changes:**
- Updated `uses: bridgecrewio/checkov-action@v12.2943.0` to `uses: bridgecrewio/checkov-action@v12` in `.github/workflows/pipeline.yml`.

**Reason for Change:**
- Dependabot has been creating frequent MRs for minor and patch updates, which adds unnecessary noise. By pinning to the major version, we can still benefit from updates while reducing the maintenance overhead.